### PR TITLE
feat: Add Firebase security rules for user recordings

### DIFF
--- a/FIREBASE_DEPLOYMENT.md
+++ b/FIREBASE_DEPLOYMENT.md
@@ -1,0 +1,108 @@
+# Firebase Security Rules Deployment Guide
+
+## Overview
+This guide explains how to deploy the Firebase security rules to fix the issue where users cannot save audio recordings without selecting a chapter.
+
+## Files Created
+- `firestore.rules` - Firestore database security rules
+- `storage.rules` - Firebase Storage security rules  
+- `firebase.json` - Firebase project configuration
+- `firestore.indexes.json` - Database indexes for performance
+
+## Prerequisites
+1. Install Firebase CLI:
+   ```bash
+   npm install -g firebase-tools
+   ```
+
+2. Login to Firebase:
+   ```bash
+   firebase login
+   ```
+
+3. Initialize Firebase project (if not already done):
+   ```bash
+   firebase init
+   ```
+   - Select Firestore and Storage
+   - Choose your existing Firebase project
+   - Accept the default files (they will be overwritten by our rules)
+
+## Deployment Steps
+
+### 1. Deploy Firestore Rules
+```bash
+firebase deploy --only firestore:rules
+```
+
+### 2. Deploy Storage Rules
+```bash
+firebase deploy --only storage
+```
+
+### 3. Deploy Both Together
+```bash
+firebase deploy --only firestore:rules,storage
+```
+
+### 4. Deploy Everything (including indexes)
+```bash
+firebase deploy
+```
+
+## Security Rules Summary
+
+### Firestore Rules (`firestore.rules`)
+- **User Documents**: Users can read/write their own user document (`/users/{userId}`)
+- **Chapters**: Users can create/manage chapters under their user document, including "Uncategorized"
+- **Recordings**: Users can create/manage recordings within their chapters
+- **Audio Files**: Users can manage their audio files
+- **Global Collections**: Authenticated users can access global collections (audio_files, transcripts, etc.)
+
+### Storage Rules (`storage.rules`)
+- **User Audio**: Users can upload/read audio files in `/users/{userId}/audio/`
+- **Chapter Recordings**: Users can upload/read recordings in `/users/{userId}/chapters/{chapterId}/recordings/`
+- **Global Storage**: Authenticated users can access global audio and recordings paths
+
+## Testing the Rules
+
+### 1. Using Firebase Emulator (Local Testing)
+```bash
+# Start emulators
+firebase emulators:start
+
+# Your app should connect to:
+# Firestore: localhost:8080
+# Storage: localhost:9199
+# UI: localhost:4000
+```
+
+### 2. Production Testing
+After deploying rules to production, test by:
+1. Authenticating a user in your frontend
+2. Trying to save a recording without selecting a chapter
+3. Verify the "Uncategorized" chapter is created automatically
+4. Confirm the recording is saved successfully
+
+## Troubleshooting
+
+### Common Issues
+1. **Permission Denied**: Ensure user is properly authenticated
+2. **Rules Not Applied**: Wait 1-2 minutes after deployment for rules to propagate
+3. **Path Mismatch**: Verify your frontend uses the correct Firestore paths matching the rules
+
+### Debugging Rules
+Use the Firebase Console Rules Playground to test specific operations:
+1. Go to Firebase Console → Firestore → Rules
+2. Click "Rules Playground"
+3. Test read/write operations with different user IDs
+
+## Frontend Path Requirements
+
+Ensure your frontend saves data using these paths:
+- **User Document**: `/users/{userId}`
+- **Chapters**: `/users/{userId}/chapters/{chapterId}` 
+- **Recordings**: `/users/{userId}/chapters/{chapterId}/recordings/{recordingId}`
+- **Storage**: `/users/{userId}/chapters/{chapterId}/recordings/{filename}`
+
+The "Uncategorized" chapter should use a consistent ID like `"uncategorized"` or generate a UUID.

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,21 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "storage": {
+    "rules": "storage.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "storage": {
+      "port": 9199
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    }
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,55 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "chapters",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "recordings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "chapterId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "audio_files",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "upload_status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,57 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Allow authenticated users to read/write their own user document
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+      
+      // Allow users to create/read/write their own chapters (including "Uncategorized")
+      match /chapters/{chapterId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+        
+        // Allow users to create/read/write recordings within their chapters
+        match /recordings/{recordingId} {
+          allow read, write: if request.auth != null && request.auth.uid == userId;
+        }
+      }
+      
+      // Allow users to manage their audio files
+      match /audio_files/{audioId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+      
+      // Allow users to manage their transcripts
+      match /transcripts/{transcriptId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+      
+      // Allow users to manage their processing jobs
+      match /processing_jobs/{jobId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+    }
+    
+    // Global collections (if needed) - restrict to authenticated users only
+    match /audio_files/{audioId} {
+      allow read, write: if request.auth != null;
+    }
+    
+    match /transcripts/{transcriptId} {
+      allow read, write: if request.auth != null;
+    }
+    
+    match /text_chunks/{chunkId} {
+      allow read, write: if request.auth != null;
+    }
+    
+    match /processing_jobs/{jobId} {
+      allow read, write: if request.auth != null;
+    }
+    
+    // Deny all other access
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,30 @@
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    // Allow authenticated users to upload/read audio files in their user directory
+    match /users/{userId}/audio/{allPaths=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+    
+    // Allow authenticated users to upload/read recordings in their chapters
+    match /users/{userId}/chapters/{chapterId}/recordings/{allPaths=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+    
+    // Global audio storage (if used) - restrict to authenticated users
+    match /audio/{allPaths=**} {
+      allow read, write: if request.auth != null;
+    }
+    
+    // Recordings storage (if used globally) - restrict to authenticated users  
+    match /recordings/{allPaths=**} {
+      allow read, write: if request.auth != null;
+    }
+    
+    // Deny all other access
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
- Add Firestore security rules allowing users to create chapters and recordings
- Add Storage security rules for user audio file uploads
- Add Firebase configuration and database indexes
- Fix issue where users couldn't save recordings without selecting a chapter
- Enable automatic 'Uncategorized' chapter creation
- Include deployment documentation

Deployed to: infinite-memoire-dev
Fixes: Recording save permission errors